### PR TITLE
fix: Ghostscript -> Poppler

### DIFF
--- a/config/poppler-layer.js
+++ b/config/poppler-layer.js
@@ -35,7 +35,7 @@ module.exports = async (serverless) => {
   const version = serverless.variables.options.imageMagickLayerVersion;
   const localVersion = await getLocalPopplerVersion();
   const layerConfig = { region, name: POPPLER_LAYER_NAME, version };
-  const layerVersion = await fetchLayerVersion('Ghostscript', localVersion, getVersionFromDescription, layerConfig);
+  const layerVersion = await fetchLayerVersion('Poppler', localVersion, getVersionFromDescription, layerConfig);
 
   return {
     'Fn::Join': [


### PR DESCRIPTION
ローカルとリモートのバージョン比較処理の出力において誤りがありました。