### PR TITLE
fix: コマンドのエラーをそのまま例外のメッセージにする

### DIFF
--- a/src/file-system.ts
+++ b/src/file-system.ts
@@ -53,15 +53,21 @@ class FileSystem {
       logger.verbose(`Executing command (${command})`);
       const process = exec(`${command}`);
 
+      let error = '';
+
       process.stdout?.on('data', (data) => { logger.debug(data); });
-      process.stderr?.on('data', (data) => { logger.error(data); });
+      process.stderr?.on('data', (data) => {
+        error += data;
+        logger.error(data);
+      });
 
       process.on('exit', (code, signal) => {
         if (code === 0) {
           logger.info(`Command finished successfully (${command})`);
           resolve();
         } else {
-          reject(new ApplicationError(ErrorCode.CommandError, `command exited with code ${code} (signal=${signal}, command=${command})`));
+          // NOTE: 明示的に `exit` していないので、stderrの出力は完了しているはずだが不明
+          reject(new ApplicationError(ErrorCode.CommandError, `command exited with code ${code} (signal=${signal}, command=${command}, stderr=${error})`));
         }
       });
     });

--- a/src/file-system.ts
+++ b/src/file-system.ts
@@ -58,6 +58,8 @@ class FileSystem {
       process.stdout?.on('data', (data) => { logger.debug(data); });
       process.stderr?.on('data', (data) => {
         error += data;
+        // 結果的に重複して出力される可能性があるが、念の為ログ出力
+        // （確実にreject時のメッセージに含まれるのであれば削除可）
         logger.error(data);
       });
 
@@ -66,8 +68,14 @@ class FileSystem {
           logger.info(`Command finished successfully (${command})`);
           resolve();
         } else {
+          const exitMsg = `command exited with code ${code} (signal=${signal}, command=${command})`;
           // NOTE: 明示的に `exit` していないので、stderrの出力は完了しているはずだが不明
-          reject(new ApplicationError(ErrorCode.CommandError, `command exited with code ${code} (signal=${signal}, command=${command}, stderr=${error})`));
+          if (error) {
+            logger.error(exitMsg);
+            reject(new ApplicationError(ErrorCode.CommandError, error));
+          } else {
+            reject(new ApplicationError(ErrorCode.CommandError, exitMsg));
+          }
         }
       });
     });


### PR DESCRIPTION
コマンドのエラーはログ出力し、実行コマンドが何だったかを例外のメッセージとして渡していますが、これだと、例外を見ただけではエラーの原因が同じかどうかが分からず、改めてログを確認する必要があります。

最初から、例外のメッセージにはコマンドのエラーメッセージをそのまま渡し、実際に実行されたコマンドについてログ出力するように変更しました。

### 備考
おそらく `stderr` の出力が完了した後に `exit` の処理が行われると思うのですが、形式的には非同期処理なので、念の為処理を分けています。
https://nodejs.org/api/process.html#process_process_exit_code